### PR TITLE
Remove usage of deprecated autovalidate parameter

### DIFF
--- a/lib/src/views/create_account.dart
+++ b/lib/src/views/create_account.dart
@@ -87,7 +87,7 @@ class _CreateAccountState extends State<CreateAccount> {
       ),
       body: Form(
         key: _formKey,
-        autovalidate: true,
+        autovalidateMode: AutovalidateMode.always,
         onChanged: () {
           setState(() {
             /* need to recheck whether the submit button should be enabled */

--- a/lib/src/views/login.dart
+++ b/lib/src/views/login.dart
@@ -238,7 +238,7 @@ class _LoginDialogState extends State<LoginDialog> {
         ),
         child: Form(
           key: _formKey,
-          autovalidate: true,
+          autovalidateMode: AutovalidateMode.always,
           onChanged: () {
             setState(() {
               /* need to recheck whether the submit button should be enabled */

--- a/lib/src/views/profile_editor.dart
+++ b/lib/src/views/profile_editor.dart
@@ -659,7 +659,7 @@ class _ChangePasswordDialogState extends State<ChangePasswordDialog> {
         ),
         child: Form(
           key: _formKey,
-          autovalidate: true,
+          autovalidateMode: AutovalidateMode.always,
           onChanged: () {
             setState(() {
               /* need to recheck whether the submit button should be enabled */


### PR DESCRIPTION
This PR is a follow up of a Flutter PR (https://github.com/flutter/flutter/pull/61648) to fix the tests of that PR in the Flutter repository. This PR just remove the usage of a deprecated parameter in favor of `autovalidateMode` introduced by https://github.com/flutter/flutter/pull/59766 in the Flutter repository.

As I talked with a Flutter member at https://github.com/flutter/flutter/pull/61648#issuecomment-659717803 he suggested me to cc @Hixie for a review.