### PR TITLE
Migrate SnackBar methods to ScaffoldMessenger

### DIFF
--- a/lib/src/views/profile_editor.dart
+++ b/lib/src/views/profile_editor.dart
@@ -258,7 +258,7 @@ class _AvatarEditorState extends State<AvatarEditor> with AutomaticKeepAliveClie
   @override
   void cancel() {
     setState(() { _busy = false; });
-    Scaffold.of(context).showSnackBar(const SnackBar(content: Text('Avatar may have changed on the server already.')));
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Avatar may have changed on the server already.')));
   }
 
   void _saveImage(ImageSource source) async {
@@ -420,7 +420,7 @@ class _ProfileFieldState extends State<ProfileField> with AutomaticKeepAliveClie
   @override
   void cancel() {
     if (_updating)
-      Scaffold.of(context).showSnackBar(SnackBar(content: Text('${widget.title} may have changed on the server already.')));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('${widget.title} may have changed on the server already.')));
     _field.text = _probableServerContents;
     setState(() { _currentlyUploadingValue = null; _saved = false; _error = null; });
   }

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -653,7 +653,7 @@ class _ChatLineState extends State<ChatLine> {
   void _handleCopy() async {
     await Clipboard.setData(ClipboardData(text: widget.messages.join('\n')));
     if (mounted)
-      Scaffold.of(context).showSnackBar(const SnackBar(content: Text('Copied to clipboard')));
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Copied to clipboard')));
   }
 
   void _handleLongPress() async {


### PR DESCRIPTION
cc/ @Hixie contact for https://github.com/flutter/tests/blob/master/registry/rainbowmonkey.test

flutter/flutter#66504 introduced the ScaffoldMessenger widget, which allows for persistent SnackBars across Scaffolds, as well as easier management of asynchronous SnackBars. The original SnackBar methods in Scaffold are going to be deprecated. Test failures were identified in this repository in flutter/flutter#67947, so this PR is intended to migrate to the new API.

Full Migration Guide:
flutter/website#4527

References:
flutter/flutter#62921
flutter/flutter#57218