### PR TITLE
Remove the AnimatedSize vsync parameter

### DIFF
--- a/lib/src/views/attach_image.dart
+++ b/lib/src/views/attach_image.dart
@@ -175,7 +175,6 @@ class AttachImageDialog extends StatelessWidget {
               return AnimatedSize(
                 duration: const Duration(milliseconds: 200),
                 curve: Curves.fastOutSlowIn,
-                vsync: vsync,
                 child: SizedBox(
                   width: 500.0,
                   child: ListView(

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -340,7 +340,6 @@ class _ProgressDialogState<T> extends State<ProgressDialog<T>> with SingleTicker
       child: AnimatedSize(
         duration: const Duration(milliseconds: 150),
         curve: Curves.fastOutSlowIn,
-        vsync: this,
         child: IntrinsicWidth(
           child: IntrinsicHeight(
             child: Padding(


### PR DESCRIPTION
This is needed in order to land https://github.com/flutter/flutter/pull/80554,
which will deprecate AnimatedSize.vsync