### PR TITLE
Removed ThemeData accentColor, accentColorBrightness, accentTextTheme dependencies

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -246,7 +246,6 @@ class CruiseMonkeyHome extends StatelessWidget {
       brightness: brightness,
       primarySwatch: Colors.blue,
       primaryColor: Colors.blue[900],
-      accentColor: accent,
       inputDecorationTheme: const InputDecorationTheme(
         border: OutlineInputBorder(),
       ),
@@ -269,6 +268,13 @@ class CruiseMonkeyHome extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(2.0)),
           ),
         ),
+      ),
+    );
+    // The color scheme's secondary color serves the same purpose as the
+    // theme's accentColor used to.
+    result = result.copyWith(
+      colorScheme: result.colorScheme.copyWith(
+        secondary: accent,
       ),
     );
     if (brightness == Brightness.dark) {
@@ -356,7 +362,7 @@ class CruiseMonkeyHome extends StatelessWidget {
                                 color: const Color(0x10FFFFFF),
                                 border: Border(
                                   top: BorderSide(
-                                    color: theme.accentColor,
+                                    color: theme.colorScheme.secondary,
                                     width: 10.0,
                                   ),
                                 ),

--- a/lib/src/views/attach_image.dart
+++ b/lib/src/views/attach_image.dart
@@ -41,7 +41,7 @@ class AttachImageButton extends StatelessWidget {
             child: images.isEmpty ? Container() : Container(
               decoration: ShapeDecoration(
                 shape: const CircleBorder(),
-                color: Theme.of(context).accentColor,
+                color: Theme.of(context).colorScheme.secondary,
               ),
               padding: const EdgeInsets.all(4.0),
               child: Text('${images.length}', style: Theme.of(context).accentTextTheme.caption),

--- a/lib/src/views/calendar.dart
+++ b/lib/src/views/calendar.dart
@@ -397,7 +397,7 @@ class TimeSlice extends StatelessWidget {
             checked: isFavorite,
             child: IconButton(
               icon: Icon(isFavorite ? Icons.favorite : Icons.favorite_border),
-              color: favoriteOverride ? theme.accentColor : null,
+              color: favoriteOverride ? theme.colorScheme.secondary : null,
               tooltip: isFavorite ? 'Unmark this event.' : 'Mark this event as interesting.',
               onPressed: isLoggedIn ? () {
                 onFavorite(!isFavorite);
@@ -482,10 +482,10 @@ class DayHeaderRow extends StatelessWidget {
     final int dayNumber = headerDay.day;
     final ThemeData theme = Theme.of(context);
     return StatusBarBackground(
-      brightness: theme.accentColorBrightness,
+      brightness: ThemeData.estimateBrightnessForColor(theme.colorScheme.secondary),
       child: Material(
-        color: theme.accentColor,
-        textStyle: theme.accentTextTheme.subtitle1,
+        color: theme.colorScheme.secondary,
+        textStyle: theme.textTheme.subtitle1.copyWith(color: theme.colorScheme.onSecondary),
         child: Container(
           padding: const EdgeInsets.all(12.0),
           child: Text('$dayOfWeek $monthName $dayNumber'),

--- a/lib/src/views/deck_plans.dart
+++ b/lib/src/views/deck_plans.dart
@@ -130,7 +130,7 @@ class _DeckPlanViewState extends State<DeckPlanView> with SingleTickerProviderSt
                   min: kMinDeck.toDouble(),
                   max: kMaxDeck.toDouble(),
                   level: _currentLevel,
-                  color: Theme.of(context).accentColor,
+                  color: Theme.of(context).colorScheme.secondary,
                 ),
                 child: DefaultTextStyle(
                   style: Theme.of(context).textTheme.button,

--- a/lib/src/views/seamail.dart
+++ b/lib/src/views/seamail.dart
@@ -575,7 +575,7 @@ class _StartSeamailViewState extends State<StartSeamailView> {
                             shape: const StadiumBorder(
                               side: BorderSide(),
                             ),
-                            color: Theme.of(context).accentColor,
+                            color: Theme.of(context).colorScheme.secondary,
                           ),
                           height: 76.0,
                           child: ClipPath(

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -1879,13 +1879,14 @@ class ModeratorBorder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Color accentColor = Theme.of(context).colorScheme.secondary;
     return AnimatedContainer(
       duration: const Duration(milliseconds: 250),
       curve: Curves.fastOutSlowIn,
       decoration: BoxDecoration(
         border: Border.all(
           width: isModerating ? 12.0 : 0,
-          color: isModerating ? Theme.of(context).accentColor : Theme.of(context).accentColor.withOpacity(0.0),
+          color: isModerating ? accentColor : accentColor.withOpacity(0.0),
         ),
       ),
       child: child,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   battery_optimization:
     dependency: "direct main"
     description:
@@ -42,21 +42,35 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -71,6 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -135,27 +156,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3+1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -205,13 +233,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -223,7 +244,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.1"
   sqflite:
     dependency: "direct main"
     description:
@@ -237,21 +258,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   synchronized:
     dependency: transitive
     description:
@@ -265,21 +286,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -314,7 +335,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   xml:
     dependency: transitive
     description:
@@ -330,5 +351,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.5"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.4.0"
   battery_optimization:
     dependency: "direct main"
     description:
@@ -42,35 +42,21 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
-  characters:
-    dependency: transitive
-    description:
-      name: characters
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -85,13 +71,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
-  fake_async:
-    dependency: transitive
-    description:
-      name: fake_async
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -156,34 +135,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3+1"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.1.8"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.6.4"
   path_provider:
     dependency: "direct main"
     description:
@@ -233,6 +205,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -244,7 +223,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.5.5"
   sqflite:
     dependency: "direct main"
     description:
@@ -258,21 +237,21 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.3"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.5"
   synchronized:
     dependency: transitive
     description:
@@ -286,21 +265,21 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.1.6"
   url_launcher:
     dependency: "direct main"
     description:
@@ -335,7 +314,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.8"
   xml:
     dependency: transitive
     description:
@@ -351,5 +330,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  dart: ">=2.6.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
Removed references to ThemeData accentColor, accentTextTheme, and accentColorBrightness because they're no longer used by the material library and will be deprecated.  Substituted the theme's colorScheme.secondary where accentColor had been used.

The ThemeData accent properties will be deprecated in https://github.com/flutter/flutter/pull/81336. 