### PR TITLE
Replaced AppBar brightness with systemOverlayStyle

### DIFF
--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -1731,7 +1731,7 @@ class PhotoImage extends StatelessWidget {
                                   curve: Curves.fastOutSlowIn,
                                   child: AppBar(
                                     backgroundColor: Colors.transparent,
-                                    brightness: Brightness.dark,
+                                    systemOverlayStyle: SystemUiOverlayStyle.light,
                                     iconTheme: const IconThemeData(color: Colors.white),
                                     actions: <Widget>[
                                       IconButton(


### PR DESCRIPTION
AppBar's brightness property will be deprecated in https://github.com/flutter/flutter/pull/86198. The new property was introduced in https://github.com/flutter/flutter/pull/71184 and has the same effect as AppBar.brightness did.